### PR TITLE
Update to CMSIS-DSP 1.16.2

### DIFF
--- a/Source/FilteringFunctions/arm_biquad_cascade_stereo_df2T_f16.c
+++ b/Source/FilteringFunctions/arm_biquad_cascade_stereo_df2T_f16.c
@@ -47,7 +47,7 @@
  */
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(ARM_DSP_BUILT_WITH_GCC)
-#pragma GCC warning "Scalar version of arm_biquad_cascade_stereo_df2T_f16 built. Helium version has build issues with gcc."
+#pragma message "Scalar version of arm_biquad_cascade_stereo_df2T_f16 built. Helium version has build issues with gcc."
 #endif 
 
 #if (defined(ARM_MATH_MVE_FLOAT16) && defined(ARM_MATH_HELIUM_EXPERIMENTAL)) && !defined(ARM_MATH_AUTOVECTORIZE) && !defined(ARM_DSP_BUILT_WITH_GCC)

--- a/Source/FilteringFunctions/arm_biquad_cascade_stereo_df2T_f16.c
+++ b/Source/FilteringFunctions/arm_biquad_cascade_stereo_df2T_f16.c
@@ -45,7 +45,12 @@
   @param[out]    pDst      points to the block of output data
   @param[in]     blockSize number of samples to process
  */
-#if (defined(ARM_MATH_MVE_FLOAT16) && defined(ARM_MATH_HELIUM_EXPERIMENTAL)) && !defined(ARM_MATH_AUTOVECTORIZE)
+
+#if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(ARM_DSP_BUILT_WITH_GCC)
+#pragma GCC warning "Scalar version of arm_biquad_cascade_stereo_df2T_f16 built. Helium version has build issues with gcc."
+#endif 
+
+#if (defined(ARM_MATH_MVE_FLOAT16) && defined(ARM_MATH_HELIUM_EXPERIMENTAL)) && !defined(ARM_MATH_AUTOVECTORIZE) && !defined(ARM_DSP_BUILT_WITH_GCC)
 ARM_DSP_ATTRIBUTE void arm_biquad_cascade_stereo_df2T_f16(
   const arm_biquad_cascade_stereo_df2T_instance_f16 * S,
   const float16_t * pSrc,

--- a/Source/FilteringFunctions/arm_correlate_q7.c
+++ b/Source/FilteringFunctions/arm_correlate_q7.c
@@ -57,7 +57,7 @@
  */
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(ARM_DSP_BUILT_WITH_GCC)
-#pragma GCC warning "Scalar version of arm_correlate_q7 built. Helium version has build issues with gcc."
+#pragma message "Scalar version of arm_correlate_q7 built. Helium version has build issues with gcc."
 #endif 
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE) &&  !defined(ARM_DSP_BUILT_WITH_GCC)

--- a/Source/FilteringFunctions/arm_correlate_q7.c
+++ b/Source/FilteringFunctions/arm_correlate_q7.c
@@ -56,7 +56,11 @@
                    Refer to \ref arm_correlate_opt_q7() for a faster implementation of this function.
  */
 
-#if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
+#if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(ARM_DSP_BUILT_WITH_GCC)
+#pragma GCC warning "Scalar version of arm_correlate_q7 built. Helium version has build issues with gcc."
+#endif 
+
+#if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE) &&  !defined(ARM_DSP_BUILT_WITH_GCC)
 #include "arm_helium_utils.h"
 
 #include "arm_vec_filtering.h"

--- a/Source/FilteringFunctions/arm_levinson_durbin_f16.c
+++ b/Source/FilteringFunctions/arm_levinson_durbin_f16.c
@@ -48,7 +48,7 @@
  */
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(ARM_DSP_BUILT_WITH_GCC)
-#pragma GCC warning "Scalar version of arm_levinson_durbin_f16 built. Helium version has build issues with gcc."
+#pragma message "Scalar version of arm_levinson_durbin_f16 built. Helium version has build issues with gcc."
 #endif 
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) &&  !defined(ARM_DSP_BUILT_WITH_GCC)

--- a/Source/FilteringFunctions/arm_levinson_durbin_f32.c
+++ b/Source/FilteringFunctions/arm_levinson_durbin_f32.c
@@ -51,7 +51,7 @@
  */
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(ARM_DSP_BUILT_WITH_GCC)
-#pragma GCC warning "Scalar version of arm_levinson_durbin_f32 built. Helium version has build issues with gcc."
+#pragma message "Scalar version of arm_levinson_durbin_f32 built. Helium version has build issues with gcc."
 #endif 
 
 #if defined(ARM_MATH_MVEF) && !defined(ARM_MATH_AUTOVECTORIZE) &&  !defined(ARM_DSP_BUILT_WITH_GCC)

--- a/Source/FilteringFunctions/arm_levinson_durbin_q31.c
+++ b/Source/FilteringFunctions/arm_levinson_durbin_q31.c
@@ -109,7 +109,7 @@ __STATIC_FORCEINLINE q31_t divide(q31_t n, q31_t d)
  */
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(ARM_DSP_BUILT_WITH_GCC)
-#pragma GCC warning "Scalar version of arm_levinson_durbin_q31 built. Helium version has build issues with gcc."
+#pragma message "Scalar version of arm_levinson_durbin_q31 built. Helium version has build issues with gcc."
 #endif 
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE) &&  !defined(ARM_DSP_BUILT_WITH_GCC)

--- a/Source/MatrixFunctions/arm_mat_cmplx_mult_f16.c
+++ b/Source/MatrixFunctions/arm_mat_cmplx_mult_f16.c
@@ -51,7 +51,11 @@
                    - \ref ARM_MATH_SIZE_MISMATCH : Matrix size check failed
  */
 
-#if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE)
+#if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(ARM_DSP_BUILT_WITH_GCC)
+#pragma GCC warning "Scalar version of arm_mat_cmplx_mult_f16 built. Helium version has build issues with gcc."
+#endif 
+
+#if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) &&  !defined(ARM_DSP_BUILT_WITH_GCC)
 
 #include "arm_helium_utils.h"
 

--- a/Source/MatrixFunctions/arm_mat_cmplx_mult_f16.c
+++ b/Source/MatrixFunctions/arm_mat_cmplx_mult_f16.c
@@ -52,7 +52,7 @@
  */
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(ARM_DSP_BUILT_WITH_GCC)
-#pragma GCC warning "Scalar version of arm_mat_cmplx_mult_f16 built. Helium version has build issues with gcc."
+#pragma message "Scalar version of arm_mat_cmplx_mult_f16 built. Helium version has build issues with gcc."
 #endif 
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) &&  !defined(ARM_DSP_BUILT_WITH_GCC)

--- a/Source/StatisticsFunctions/arm_absmax_q7.c
+++ b/Source/StatisticsFunctions/arm_absmax_q7.c
@@ -46,7 +46,7 @@
  */
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(ARM_DSP_BUILT_WITH_GCC)
-#pragma GCC warning "Scalar version of arm_absmax_q7 built. Helium version has build issues with gcc."
+#pragma message "Scalar version of arm_absmax_q7 built. Helium version has build issues with gcc."
 #endif 
 
 

--- a/Source/StatisticsFunctions/arm_absmax_q7.c
+++ b/Source/StatisticsFunctions/arm_absmax_q7.c
@@ -45,7 +45,12 @@
   @param[out]    pIndex     index of maximum value returned here
  */
 
-#if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
+#if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(ARM_DSP_BUILT_WITH_GCC)
+#pragma GCC warning "Scalar version of arm_absmax_q7 built. Helium version has build issues with gcc."
+#endif 
+
+
+#if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE) &&  !defined(ARM_DSP_BUILT_WITH_GCC)
 
 #include <stdint.h>
 #include "arm_helium_utils.h"

--- a/Source/SupportFunctions/arm_f16_to_float.c
+++ b/Source/SupportFunctions/arm_f16_to_float.c
@@ -53,7 +53,7 @@
  */
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(ARM_DSP_BUILT_WITH_GCC)
-#pragma GCC warning "Scalar version of arm_f16_to_float built. Helium version has build issues with gcc."
+#pragma message "Scalar version of arm_f16_to_float built. Helium version has build issues with gcc."
 #endif 
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) &&  !defined(ARM_DSP_BUILT_WITH_GCC)

--- a/Source/SupportFunctions/arm_float_to_f16.c
+++ b/Source/SupportFunctions/arm_float_to_f16.c
@@ -48,7 +48,7 @@
  */
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(ARM_DSP_BUILT_WITH_GCC)
-#pragma GCC warning "Scalar version of arm_float_to_f16 built. Helium version has build issues with gcc."
+#pragma message "Scalar version of arm_float_to_f16 built. Helium version has build issues with gcc."
 #endif 
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) &&  !defined(ARM_DSP_BUILT_WITH_GCC)

--- a/Source/TransformFunctions/arm_rfft_q15.c
+++ b/Source/TransformFunctions/arm_rfft_q15.c
@@ -159,6 +159,11 @@ ARM_DSP_ATTRIBUTE void arm_rfft_q15(
 #include "arm_helium_utils.h"
 #include "arm_vec_fft.h"
 
+#if defined(ARM_DSP_BUILT_WITH_GCC)
+#define MVE_CMPLX_MULT_FX_AxB_S16(A,B)          vqdmladhxq_s16(vqdmlsdhq_s16((__typeof(A))vuninitializedq_s16(), A, B), A, B)
+#define MVE_CMPLX_MULT_FX_AxConjB_S16(A,B)      vqdmladhq_s16(vqdmlsdhxq_s16((__typeof(A))vuninitializedq_s16(), A, B), A, B)
+
+#endif 
 
 ARM_DSP_ATTRIBUTE void arm_split_rfft_q15(
         q15_t * pSrc,
@@ -200,9 +205,13 @@ ARM_DSP_ATTRIBUTE void arm_split_rfft_q15(
         q15x8_t         coefA = vldrhq_gather_shifted_offset_s16(pCoefAb, offsetCoef);
         q15x8_t         coefB = vldrhq_gather_shifted_offset_s16(pCoefBb, offsetCoef);
 
-
+#if defined(ARM_DSP_BUILT_WITH_GCC)
+        q15x8_t         out = vhaddq_s16(MVE_CMPLX_MULT_FX_AxB_S16(in1, coefA),
+                                     MVE_CMPLX_MULT_FX_AxConjB_S16(coefB, in2));
+#else
         q15x8_t         out = vhaddq_s16(MVE_CMPLX_MULT_FX_AxB(in1, coefA, q15x8_t),
                                          MVE_CMPLX_MULT_FX_AxConjB(coefB, in2, q15x8_t));
+#endif
         vst1q_s16(pOut1, out);
         pOut1 += 8;
 

--- a/Source/TransformFunctions/arm_rfft_q31.c
+++ b/Source/TransformFunctions/arm_rfft_q31.c
@@ -157,6 +157,12 @@ ARM_DSP_ATTRIBUTE void arm_rfft_q31(
 #include "arm_helium_utils.h"
 #include "arm_vec_fft.h"
 
+#if defined(ARM_DSP_BUILT_WITH_GCC)
+
+#define MVE_CMPLX_MULT_FX_AxB_S32(A,B)          vqdmladhxq_s32(vqdmlsdhq_s32((__typeof(A))vuninitializedq_s32(), A, B), A, B)
+#define MVE_CMPLX_MULT_FX_AxConjB_S32(A,B)      vqdmladhq_s32(vqdmlsdhxq_s32((__typeof(A))vuninitializedq_s32(), A, B), A, B)
+
+#endif 
 
 ARM_DSP_ATTRIBUTE void arm_split_rfft_q31(
     q31_t       *pSrc,
@@ -193,9 +199,12 @@ ARM_DSP_ATTRIBUTE void arm_split_rfft_q31(
         q31x4_t         in2 = vldrwq_gather_shifted_offset_s32(pSrc, offset);
         q31x4_t         coefA = vldrwq_gather_shifted_offset_s32(pCoefAb, offsetCoef);
         q31x4_t         coefB = vldrwq_gather_shifted_offset_s32(pCoefBb, offsetCoef);
-
+#if defined(ARM_DSP_BUILT_WITH_GCC)
+        q31x4_t         out = vhaddq_s32(MVE_CMPLX_MULT_FX_AxB_S32(in1, coefA),MVE_CMPLX_MULT_FX_AxConjB_S32(coefB, in2));
+#else
         q31x4_t         out = vhaddq_s32(MVE_CMPLX_MULT_FX_AxB(in1, coefA, q31x4_t),
                                          MVE_CMPLX_MULT_FX_AxConjB(coefB, in2, q31x4_t));
+#endif
         vst1q(pOut1, out);
         pOut1 += 4;
 
@@ -348,9 +357,13 @@ ARM_DSP_ATTRIBUTE void arm_split_rifft_q31(
         q31x4_t         coefB = vldrwq_gather_shifted_offset_s32(pCoefBb, offsetCoef);
 
         /* can we avoid the conjugate here ? */
+#if defined(ARM_DSP_BUILT_WITH_GCC)
+        q31x4_t         out = vhaddq_s32(MVE_CMPLX_MULT_FX_AxConjB_S32(in1, coefA),
+                                     vmulq_s32(conj, MVE_CMPLX_MULT_FX_AxB_S32(in2, coefB)));
+#else
         q31x4_t         out = vhaddq_s32(MVE_CMPLX_MULT_FX_AxConjB(in1, coefA, q31x4_t),
                                          vmulq_s32(conj, MVE_CMPLX_MULT_FX_AxB(in2, coefB, q31x4_t)));
-
+#endif
         vst1q_s32(pDst, out);
         pDst += 4;
 

--- a/dsppp/Include/dsppp/arch_detection.hpp
+++ b/dsppp/Include/dsppp/arch_detection.hpp
@@ -16,12 +16,6 @@ extern "C"
 #elif defined ( __APPLE_CC__ )
   #pragma GCC diagnostic ignored "-Wold-style-cast"
 
-#elif defined(__clang__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wsign-conversion"
-  #pragma GCC diagnostic ignored "-Wconversion"
-  #pragma GCC diagnostic ignored "-Wunused-parameter"
-
 #elif defined ( __GNUC__ )
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wsign-conversion"

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 Meta Platforms <ryanmcclelland@meta.com>
+# SPDX-License-Identifier: Apache-2.0
+
+name: cmsis-dsp
+build:
+  cmake-ext: True
+  kconfig-ext: True


### PR DESCRIPTION
This updates the zephyr module to the CMSIS-DSP 1.16.2 tag. This includes 2 commits with changing a warning to a message along with the adding the `zephyr.yml` module folder

It appears there quite the headache with the branches in this module.... I'm not quite sure what the best process would be here